### PR TITLE
Make result_type configurable via template parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ library is single header-only and has zero dependency.
 
 int main()
 {
-    // Distribution of four events with these weights.
-    cxx::discrete_distribution distr = {1.2, 3.4, 5.6, 7.8};
+    // Distribution of four events (0, 1, 2 or 3) with given weights.
+    cxx::discrete_distribution<int> distr = {1.2, 3.4, 5.6, 7.8};
     std::mt19937_64 random;
 
     // 0, 1, 2 or 3 is chosen.
-    std::size_t choice = distr(random);
+    int choice = distr(random);
 
     // Change the weight of the event 1 to zero.
     distr.update(1, 0.0);

--- a/example/gillespie/main.cc
+++ b/example/gillespie/main.cc
@@ -35,7 +35,7 @@ int main()
     // Discrete distribution of N reactions. We will update the rates
     // (weights) based on the number of species.
     std::vector<double> const initial_rate(num_species, 0.0);
-    cxx::discrete_distribution reaction_distr{initial_rate};
+    cxx::discrete_distribution<std::size_t> reaction_distr{initial_rate};
 
     // Simulation state.
     std::vector<int> species(num_species);

--- a/include/discrete_distribution.hpp
+++ b/include/discrete_distribution.hpp
@@ -389,6 +389,7 @@ namespace cxx
     /*
      * Distribution of random integers with given weights.
      */
+    template<typename T = int>
     class discrete_distribution
     {
     public:
@@ -396,7 +397,7 @@ namespace cxx
         /*
          * Type of generated integer.
          */
-        using result_type = std::size_t;
+        using result_type = T;
 
 
         /*
@@ -406,7 +407,7 @@ namespace cxx
         {
         public:
 
-            using distribution_type = cxx::discrete_distribution;
+            using distribution_type = cxx::discrete_distribution<T>;
 
 
             // Inherit constructors from discrete_weights.
@@ -517,7 +518,7 @@ namespace cxx
         result_type
         max() const
         {
-            return _weights.size() - 1;
+            return result_type(_weights.size() - 1);
         }
 
 
@@ -548,7 +549,7 @@ namespace cxx
         void
         update(result_type i, double weight)
         {
-            return _weights.update(i, weight);
+            return _weights.update(std::size_t(i), weight);
         }
 
 
@@ -566,7 +567,7 @@ namespace cxx
         operator()(RNG& random) const
         {
             std::uniform_real_distribution<double> uniform{0.0, _weights.sum()};
-            return _weights.find(uniform(random));
+            return result_type(_weights.find(uniform(random)));
         }
 
 
@@ -575,34 +576,36 @@ namespace cxx
     };
 
 
+    template<typename T>
     inline bool
     operator==(
-        cxx::discrete_distribution const& d1,
-        cxx::discrete_distribution const& d2
+        cxx::discrete_distribution<T> const& d1,
+        cxx::discrete_distribution<T> const& d2
     )
     {
         return d1.param() == d2.param();
     }
 
 
+    template<typename T>
     inline bool
     operator!=(
-        cxx::discrete_distribution const& d1,
-        cxx::discrete_distribution const& d2
+        cxx::discrete_distribution<T> const& d1,
+        cxx::discrete_distribution<T> const& d2
     )
     {
         return !(d1 == d2);
     }
 
 
-    template<typename Char, typename Tr>
+    template<typename Char, typename Tr, typename T>
     std::basic_istream<Char, Tr>&
     operator>>(
         std::basic_istream<Char, Tr>& is,
-        cxx::discrete_distribution& distr
+        cxx::discrete_distribution<T>& distr
     )
     {
-        using param_type = cxx::discrete_distribution::param_type;
+        using param_type = typename cxx::discrete_distribution<T>::param_type;
         param_type param;
         is >> param;
         distr.param(param);
@@ -610,11 +613,11 @@ namespace cxx
     }
 
 
-    template<typename Char, typename Tr>
+    template<typename Char, typename Tr, typename T>
     std::basic_ostream<Char, Tr>&
     operator<<(
         std::basic_ostream<Char, Tr>& os,
-        cxx::discrete_distribution const& distr
+        cxx::discrete_distribution<T> const& distr
     )
     {
         return os << distr.param();

--- a/test/test_discrete_distribution.cc
+++ b/test/test_discrete_distribution.cc
@@ -15,7 +15,7 @@
 
 TEST_CASE("discrete_distribution - is default constructible")
 {
-    cxx::discrete_distribution distr;
+    cxx::discrete_distribution<int> distr;
     (void) distr;
 }
 
@@ -24,27 +24,27 @@ TEST_CASE("discrete_distribution - is constructible from weights")
 {
     // Vector
     std::vector<double> const values = {1.0, 2.0, 3.0};
-    cxx::discrete_distribution distr_v{values};
+    cxx::discrete_distribution<int> distr_v{values};
     (void) distr_v;
 
     // Initializer list
-    cxx::discrete_distribution distr_i = {1.0, 2.0, 3.0};
+    cxx::discrete_distribution<int> distr_i = {1.0, 2.0, 3.0};
     (void) distr_i;
 
     // Weights
     cxx::discrete_weights weights = {1.0, 2.0, 3.0};
-    cxx::discrete_distribution distr_w{weights};
+    cxx::discrete_distribution<int> distr_w{weights};
     (void) distr_w;
 }
 
 
 TEST_CASE("discrete_distribution - is equality comparable")
 {
-    cxx::discrete_distribution const distr_A = {1.2, 3.4, 5.6};
-    cxx::discrete_distribution const distr_B = {1.2, 3.4, 5.6};
-    cxx::discrete_distribution const distr_C = {5.6, 3.4, 1.2};
-    cxx::discrete_distribution const distr_D = {1.2, 3.4, 5.6, 7.8};
-    cxx::discrete_distribution const distr_E = {1.2, 3.4};
+    cxx::discrete_distribution<int> const distr_A = {1.2, 3.4, 5.6};
+    cxx::discrete_distribution<int> const distr_B = {1.2, 3.4, 5.6};
+    cxx::discrete_distribution<int> const distr_C = {5.6, 3.4, 1.2};
+    cxx::discrete_distribution<int> const distr_D = {1.2, 3.4, 5.6, 7.8};
+    cxx::discrete_distribution<int> const distr_E = {1.2, 3.4};
 
     CHECK(distr_A == distr_A);
     CHECK(distr_A == distr_B);
@@ -56,9 +56,9 @@ TEST_CASE("discrete_distribution - is equality comparable")
 
 TEST_CASE("discrete_distribution - is copyable")
 {
-    cxx::discrete_distribution origin = {1.0, 2.0, 3.0};
-    cxx::discrete_distribution clone = origin;
-    cxx::discrete_distribution distr;
+    cxx::discrete_distribution<int> origin = {1.0, 2.0, 3.0};
+    cxx::discrete_distribution<int> clone = origin;
+    cxx::discrete_distribution<int> distr;
 
     distr = origin;
 
@@ -70,15 +70,15 @@ TEST_CASE("discrete_distribution - is copyable")
 TEST_CASE("discrete_distribution::reset - is defined")
 {
     // Just a RandomNumberDistribution requirement.
-    cxx::discrete_distribution distr;
+    cxx::discrete_distribution<int> distr;
     distr.reset();
 }
 
 
 TEST_CASE("discrete_distribution::param - roundtrip works")
 {
-    cxx::discrete_distribution const origin = {1.2, 3.4, 5.6};
-    cxx::discrete_distribution distr;
+    cxx::discrete_distribution<int> const origin = {1.2, 3.4, 5.6};
+    cxx::discrete_distribution<int> distr;
 
     distr.param(origin.param());
 
@@ -89,7 +89,7 @@ TEST_CASE("discrete_distribution::param - roundtrip works")
 TEST_CASE("discrete_distribution::param - is-a discrete_weights")
 {
     cxx::discrete_weights const expected_weights = {1.2, 3.4, 5.6};
-    cxx::discrete_distribution const distr{expected_weights};
+    cxx::discrete_distribution<int> const distr{expected_weights};
 
     cxx::discrete_weights const& weights = distr.param();
     CHECK(weights == expected_weights);
@@ -98,15 +98,15 @@ TEST_CASE("discrete_distribution::param - is-a discrete_weights")
 
 TEST_CASE("discrete_distribution::min/max - returns correct bounds")
 {
-    cxx::discrete_distribution const distr1 = {1.0};
+    cxx::discrete_distribution<int> const distr1 = {1.0};
     CHECK(distr1.min() == 0);
     CHECK(distr1.max() == 0);
 
-    cxx::discrete_distribution const distr2 = {1.0, 2.0};
+    cxx::discrete_distribution<int> const distr2 = {1.0, 2.0};
     CHECK(distr2.min() == 0);
     CHECK(distr2.max() == 1);
 
-    cxx::discrete_distribution const distr3 = {1.0, 2.0, 3.0};
+    cxx::discrete_distribution<int> const distr3 = {1.0, 2.0, 3.0};
     CHECK(distr3.min() == 0);
     CHECK(distr3.max() == 2);
 }
@@ -114,14 +114,14 @@ TEST_CASE("discrete_distribution::min/max - returns correct bounds")
 
 TEST_CASE("discrete_distribution::sum - returns correct weight sum")
 {
-    cxx::discrete_distribution const distr = {1.2, 3.4, 5.6};
+    cxx::discrete_distribution<int> const distr = {1.2, 3.4, 5.6};
     CHECK(distr.sum() == Approx(1.2 + 3.4 + 5.6));
 }
 
 
 TEST_CASE("discrete_distribution::update - updates weight value")
 {
-    cxx::discrete_distribution distr = {1.2, 3.4, 5.6};
+    cxx::discrete_distribution<int> distr = {1.2, 3.4, 5.6};
 
     auto const& weights = distr.param();
     REQUIRE(weights[0] == 1.2);
@@ -145,7 +145,7 @@ TEST_CASE("discrete_distribution - generates values in correct probability")
 
     // Sample from the discrete distribution and construct an empirical
     // distribution (histogram).
-    cxx::discrete_distribution distr{weights};
+    cxx::discrete_distribution<std::size_t> distr{weights};
 
     int const sample_count = 10000;
     std::mt19937_64 random;
@@ -169,7 +169,7 @@ TEST_CASE("discrete_distribution - generates values in correct probability")
 
 TEST_CASE("discrete_distribution - changes distribution on the fly")
 {
-    cxx::discrete_distribution distr = {1.0, 0.0};
+    cxx::discrete_distribution<int> distr = {1.0, 0.0};
     std::mt19937_64 random;
 
     // Now the distribution is {1, 0}, so only the first event occurs.


### PR DESCRIPTION
This PR changes `cxx::discrete_distribution` to a class template accepting a type. The type is used as the configurable `result_type`. See #2.